### PR TITLE
Co search

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -6,6 +6,7 @@ const pluto = require('../search-helpers/pluto');
 const zoningDistrict = require('../search-helpers/zoning-district');
 const zoningMapAmendment = require('../search-helpers/zoning-map-amendment');
 const specialPurposeDistrict = require('../search-helpers/special-purpose-district');
+const commercialOverlay = require('../search-helpers/commercial-overlay');
 
 const router = express.Router();
 
@@ -19,11 +20,12 @@ router.get('/', (req, res) => {
     zoningDistrict(q),
     zoningMapAmendment(q),
     specialPurposeDistrict(q),
+    commercialOverlay(q),
   ])
     .then((values) => {
-      const [addresses, neighborhoods, lots, zoningDistricts, zmas, spdistricts] = values;
+      const [addresses, neighborhoods, lots, zoningDistricts, zmas, spdistricts, commercialOverlay] = values;
       const responseArray = [];
-      res.json(responseArray.concat(addresses, neighborhoods, lots, zoningDistricts, zmas, spdistricts));
+      res.json(responseArray.concat(addresses, neighborhoods, lots, zoningDistricts, zmas, spdistricts, commercialOverlay));
     }).catch((reason) => {
       console.error(reason); // eslint-disable-line
     });

--- a/search-helpers/commercial-overlay.js
+++ b/search-helpers/commercial-overlay.js
@@ -1,19 +1,17 @@
 const carto = require('../utils/carto');
 
-const commercialOverlay = (string) => {
-  const SQL = `
-    SELECT DISTINCT overlay, cartodb_id
-    FROM support_zoning_co
-    WHERE LOWER(overlay) LIKE LOWER('%25${string.toLowerCase()}%25')
-    LIMIT 5
-  `;
+const overlays = ['C1-1', 'C1-2', 'C1-3', 'C1-4', 'C1-5', 'C2-1', 'C2-2', 'C2-3', 'C2-4', 'C2-5'];
 
-  return carto.SQL(SQL).then(rows =>
-    rows.map((row) => {
-      row.label = row.overlay;
-      row.type = 'commercial-overlay';
-      return row;
+const commercialOverlay = (string) => {
+
+  return new Promise((resolve) => {
+    const matches = overlays.filter(overlay => overlay.toLowerCase().indexOf(string.toLowerCase()) !== -1);
+    const results = matches.map(result => ({
+      label: result,
+      type: 'commercial-overlay',
     }));
+    resolve(results);
+  });
 };
 
 module.exports = commercialOverlay;

--- a/search-helpers/commercial-overlay.js
+++ b/search-helpers/commercial-overlay.js
@@ -1,0 +1,19 @@
+const carto = require('../utils/carto');
+
+const commercialOverlay = (string) => {
+  const SQL = `
+    SELECT DISTINCT overlay, cartodb_id
+    FROM support_zoning_co
+    WHERE LOWER(overlay) LIKE LOWER('%25${string.toLowerCase()}%25')
+    LIMIT 5
+  `;
+
+  return carto.SQL(SQL).then(rows =>
+    rows.map((row) => {
+      row.label = row.overlay;
+      row.type = 'commercial-overlay';
+      return row;
+    }));
+};
+
+module.exports = commercialOverlay;


### PR DESCRIPTION
Refactors commercial overlay search helper:

- Does not do an API call to carto as there are only 10 possible commercial overlay types
- Builds its own promise and does the string matching in javascript

Search for "c2-" returns C2-1, C2-2, C2-3, C2-4, C2-5

Search for "c2-5 returns only a single result: C2-5